### PR TITLE
refactor requirement.es

### DIFF
--- a/ExpeditionTable.es
+++ b/ExpeditionTable.es
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 
 import { enumFromTo } from './utils'
-import { getExpedReqs, checkAllReq, collapseResults } from './requirement'
+import { checkExpedReqs } from './requirement'
 
 import {
   Button,
@@ -11,12 +11,6 @@ import {
 
 import { expedInfo } from './exped-info'
 const { _ } = window
-
-const checkWithoutResupply = (fleet, expedId) => {
-  const req = getExpedReqs(expedId,false,false).norm
-  const result = checkAllReq( req )(fleet)
-  return collapseResults(result)
-}
 
 const mkExpedTooltip = expedId => {
   const info = expedInfo[expedId]
@@ -80,7 +74,8 @@ class ExpeditionTable extends Component {
     const isReadyArr = new Array(40+1)
     enumFromTo(1,40)
       .map( expedId => 
-        isReadyArr[expedId] = checkWithoutResupply(this.props.fleet,expedId) )
+        isReadyArr[expedId] =
+          checkExpedReqs(expedId,false,false)(this.props.fleet))
     return (
       <div style={{display: "flex"}} >
         {enumFromTo(1,5).map(world =>

--- a/ExpeditionTable.es
+++ b/ExpeditionTable.es
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 
 import { enumFromTo } from './utils'
-import { expedReqs, checkAllReq, collapseResults } from './requirement'
+import { getExpedReqs, checkAllReq, collapseResults } from './requirement'
 
 import {
   Button,
@@ -13,8 +13,7 @@ import { expedInfo } from './exped-info'
 const { _ } = window
 
 const checkWithoutResupply = (fleet, expedId) => {
-  const req = expedReqs[expedId]
-    .filter( req => Array.isArray(req) || req.data.type !== "Resupply" )
+  const req = getExpedReqs(expedId,false,false).norm
   const result = checkAllReq( req )(fleet)
   return collapseResults(result)
 }

--- a/FleetPicker.es
+++ b/FleetPicker.es
@@ -6,7 +6,7 @@ import {
   Tooltip,
 } from 'react-bootstrap'
 
-import { expedReqs, expedGSReqs, checkAllReq, collapseResults } from './requirement'
+import { getExpedReqs, checkAllReq, collapseResults } from './requirement'
 const { FontAwesome } = window
 
 import { __ } from './tr'
@@ -53,9 +53,11 @@ class FleetPicker extends Component {
       const expedId = this.props.config.selectedExpeds[fleetId]
       const greatSuccess = this.props.config.gsFlags[expedId]
 
-      const normReqs = expedReqs[expedId]
-      const normReqsWOResupply = normReqs
-        .filter( r => Array.isArray(r) || r.data.type !== "Resupply" )
+      const eR = getExpedReqs(expedId,true,true)
+      const normReqs = [...eR.norm]
+      normReqs.push( eR.resupply )
+
+      const normReqsWOResupply = eR.norm
       const normReadyFlag = 
         collapseResults( checkAllReq( normReqs )(fleet) )
       const normReadyFlagWOResupply = 
@@ -63,7 +65,7 @@ class FleetPicker extends Component {
 
       const gsReadyFlag = 
         !greatSuccess ||
-        (greatSuccess && collapseResults( checkAllReq( expedGSReqs[expedId ] )(fleet) ))
+        (greatSuccess && collapseResults( checkAllReq( eR.gs )(fleet) ))
 
       const bsStyle =
           fleetId === 0 ? "success"

--- a/FleetPicker.es
+++ b/FleetPicker.es
@@ -52,16 +52,13 @@ class FleetPicker extends Component {
       const fleetExtra = this.props.fleetsExtra[fleetId]
       const expedId = this.props.config.selectedExpeds[fleetId]
       const greatSuccess = this.props.config.gsFlags[expedId]
-
+      
       const eR = getExpedReqs(expedId,true,true)
-      const normReqs = [...eR.norm]
-      normReqs.push( eR.resupply )
 
-      const normReqsWOResupply = eR.norm
+      const resupplyReadyFlag = checkAllReq(eR.resupply)(fleet)
+      // without resupply
       const normReadyFlag = 
-        collapseResults( checkAllReq( normReqs )(fleet) )
-      const normReadyFlagWOResupply = 
-        collapseResults( checkAllReq( normReqsWOResupply )(fleet) )
+        collapseResults( checkAllReq( eR.norm )(fleet) )
 
       const gsReadyFlag = 
         !greatSuccess ||
@@ -71,8 +68,8 @@ class FleetPicker extends Component {
           fleetId === 0 ? "success"
         : this.props.combinedFlag !== 0 && fleetId === 1 ? "success"
         : !fleetExtra.available ? "primary"
-        : normReadyFlag && gsReadyFlag ? "success"
-        : normReadyFlagWOResupply && gsReadyFlag ? "warning"
+        : normReadyFlag && resupplyReadyFlag && gsReadyFlag ? "success"
+        : normReadyFlag && gsReadyFlag ? "warning"
         : "danger"
 
       const focused = this.props.fleetId === fleetId

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ is to take a look at unmet requirements and adjust your fleet & equipments accor
 ### Accurate Resource Income Estimation
 
 Great Success, all kinds of Daihatsu Landing Craft, their improvement levels
-and resuply cost, all taken into account.
+and resupply cost, all taken into account.
 
 ![](docs/income1.jpg)
 

--- a/RequirementViewer.es
+++ b/RequirementViewer.es
@@ -9,8 +9,7 @@ import {
 } from 'react-bootstrap'
 
 import { 
-  getExpedReqs,
-  checkAllReq, 
+  checkExpedDetail,
   collapseResults,
   isEqualReqObj,
 } from './requirement'
@@ -157,46 +156,46 @@ class RequirementViewer extends Component {
   }
 
   render() {
-    const fleet = this.props.fleet
+    const resultDetail = checkExpedDetail(this.props.expedId,true,true)(this.props.fleet)
+    const normCheckResult = collapseResults( resultDetail.norm.map( ([req,res]) => res) )
+    const resupplyCheckResult = resultDetail.resupply[1]
+    const gsCheckResult = collapseResults( resultDetail.gs.map( ([req,res]) => res ) )
 
-    const eR = getExpedReqs(this.props.expedId,true,true)
+    const normFlg = normCheckResult && resupplyCheckResult
+    const gsFlg = normFlg && gsCheckResult
 
-    const normReqObj = [...eR.norm]
-    normReqObj.push( eR.resupply )
-
-    const normResultObj = checkAllReq(normReqObj)(fleet)
-    const normCheckResult = collapseResults( normResultObj )
-    const normPairedObj = _.zip(normReqObj,normResultObj)
-    const gsReqObj = eR.gs
-    const gsResultObj = checkAllReq(gsReqObj)(fleet)
-    const gsCheckResult = normCheckResult && collapseResults( gsResultObj )
-    const gsPairedObj = _.zip(gsReqObj,gsResultObj)
     const readyOrNot = flg => __(flg ? "CondReady" : "CondNotReady")
     return (
       <div>
         <div style={{display: "flex", justifyContent: "space-between"}}>
           <CheckResultBox
-              ready={normCheckResult} visible={true}
+              ready={normFlg} visible={true}
               content={`${__("CondNormal")}: ${readyOrNot(normCheckResult)}`} />
           <CheckResultBox
-              ready={gsCheckResult} visible={this.props.greatSuccess}
+              ready={gsFlg} visible={this.props.greatSuccess}
               content={`${__("CondGreatSuccess")}: ${readyOrNot(gsCheckResult)}`} />
         </div>
         <ListGroup>
-          { normPairedObj.map( ([req,res],ind) =>
+          { resultDetail.norm.map( ([req,res],ind) =>
               <RequirementListItem
                   key={`norm-${ind}`}
                   req={req}
                   ok={res}
                   greatSuccess={false} />)}
+          <RequirementListItem
+              key="resupply"
+              req={resultDetail.resupply[0]}
+              ok={resultDetail.resupply[1]}
+              greatSuccess={false} />
           { this.props.greatSuccess &&
-            gsPairedObj.map( ([req,res],ind) =>
+            resultDetail.gs.map( ([req,res],ind) =>
               <RequirementListItem
                   key={`gs-${ind}`}
                   req={req}
                   ok={res}
                   greatSuccess={true}
               />) }
+
         </ListGroup>
       </div>
     )

--- a/RequirementViewer.es
+++ b/RequirementViewer.es
@@ -9,8 +9,7 @@ import {
 } from 'react-bootstrap'
 
 import { 
-  expedReqs, 
-  expedGSReqs, 
+  getExpedReqs,
   checkAllReq, 
   collapseResults,
   isEqualReqObj,
@@ -18,7 +17,6 @@ import {
 
 import * as estype from './estype'
 import { __ } from './tr'
-import * as dbg from './debug'
 
 // a box for showing whether the fleet is ready
 // props:
@@ -160,11 +158,16 @@ class RequirementViewer extends Component {
 
   render() {
     const fleet = this.props.fleet
-    const normReqObj = expedReqs[ this.props.expedId ]
+
+    const eR = getExpedReqs(this.props.expedId,true,true)
+
+    const normReqObj = [...eR.norm]
+    normReqObj.push( eR.resupply )
+
     const normResultObj = checkAllReq(normReqObj)(fleet)
     const normCheckResult = collapseResults( normResultObj )
     const normPairedObj = _.zip(normReqObj,normResultObj)
-    const gsReqObj = expedGSReqs[ this.props.expedId ]
+    const gsReqObj = eR.gs
     const gsResultObj = checkAllReq(gsReqObj)(fleet)
     const gsCheckResult = normCheckResult && collapseResults( gsResultObj )
     const gsPairedObj = _.zip(gsReqObj,gsResultObj)

--- a/RequirementViewer.es
+++ b/RequirementViewer.es
@@ -49,7 +49,7 @@ const renderRequirement = (req,ok) => {
               style={{marginRight: "5px", marginTop: "2px"}}
               name={ok[ind] ? "check-square-o" : "square-o"} />
             <div style={{flex:"1", whiteSpace: "nowrap"}}>
-              {`${estype.longDesc(data.estype)} x ${data.count}`}
+              {`${estype.longDesc(__)(data.estype)} x ${data.count}`}
             </div>
           </div>)}
       </div>
@@ -76,7 +76,7 @@ const renderRequirement = (req,ok) => {
   }
 
   if (req.data.type === "FSType") {
-    return fmt(estype.longDesc(req.data.estype))
+    return fmt(estype.longDesc(__)(req.data.estype))
   }
 
   if (req.data.type === "FSLevel") {

--- a/estype.es
+++ b/estype.es
@@ -15,7 +15,7 @@ import { throwWith } from './utils'
 
 const stype = readJsonSync(join(__dirname, 'assets', 'stypes.json'))
 const allSTypes = Object.keys( stype )
-import { __ } from './tr'
+// import { __ } from './tr'
 
 // for reverse lookup
 const stypeRev = (() => {
@@ -54,7 +54,9 @@ const shortDesc = estypeName =>
   : estypeName === "SSLike" ? "SS*"
   : estypeName
 
-const longDesc = estypeName => {
+// note: in order to keep this module pure for testing,
+// one has to provide a translating function, which for now is "__" from "tr.es"
+const longDesc = __ => estypeName => {
   const text = `ShipTypeNameLong.${estypeName}`
   const translated = __(text)
   if (text === translated)

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "path-extra": "^4.1.0"
   },
   "devDependencies": {
-    "mocha": "^3.2.0",
     "babel-core": "^6.24.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015-node6": "^0.4.0",
     "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-0": "^6.22.0"
+    "babel-preset-stage-0": "^6.22.0",
+    "lodash": "^4.17.4",
+    "mocha": "^3.2.0"
   }
 }

--- a/requirement.es
+++ b/requirement.es
@@ -208,7 +208,6 @@ const mkSTypeReqs = function () {
 const expedReqs = (() => {
   const ret = new Array(40+1)
 
-  const basicReqs = [ Req.Resupply ]
   const flagshipLevelAndShipCount = (fsl,sc) =>
     [Req.FSLevel(fsl), Req.ShipCount(sc)]
 
@@ -219,98 +218,78 @@ const expedReqs = (() => {
 
   ret[1] = [
     ...flagshipLevelAndShipCount(1,2),
-    ...basicReqs,
     Req.Morale(28),
   ]
 
   ret[2] = [
     ...flagshipLevelAndShipCount(2,4),
-    ...basicReqs,
     Req.Morale(13),
   ]
 
   ret[3] = [
     ...flagshipLevelAndShipCount(3,3),
-    ...basicReqs,
     Req.Morale(22),
   ]
 
   ret[4] = [
     ...flagshipLevelAndShipCount(3,3),
     mkSTypeReqs(1,"CL", 2,"DD"),
-    ...basicReqs,
   ]
 
   ret[5] = [
     ...flagshipLevelAndShipCount(3,4),
     mkSTypeReqs(1,"CL", 2,"DD"),
-    ...basicReqs,
   ]
 
   ret[6] = [
     ...flagshipLevelAndShipCount(4,4),
-    ...basicReqs,
     Req.Morale(1),
   ]
 
-  ret[7] = [
-    ...flagshipLevelAndShipCount(5,6),
-    ...basicReqs,
-  ]
+  ret[7] = flagshipLevelAndShipCount(5,6)
 
-  ret[8] = [
-    ...flagshipLevelAndShipCount(6,6),
-    ...basicReqs,
-  ]
+  ret[8] = flagshipLevelAndShipCount(6,6)
 
   // world 2
 
   ret[9] = [
     ...flagshipLevelAndShipCount(3,4),
     mkSTypeReqs(1,"CL",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[10] = [
     ...flagshipLevelAndShipCount(3,3),
     mkSTypeReqs(2,"CL"),
-    ...basicReqs,
   ]
 
   ret[11] = [
     ...flagshipLevelAndShipCount(6,4),
     mkSTypeReqs(2,"DD"),
-    ...basicReqs,
   ]
 
   ret[12] = [
     ...flagshipLevelAndShipCount(4,4),
     mkSTypeReqs(2,"DD"),
-    ...basicReqs,
   ]
 
   ret[13] = [
     ...flagshipLevelAndShipCount(5,6),
     mkSTypeReqs(1,"CL",4,"DD"),
-    ...basicReqs,
   ]
 
   ret[14] = [
     ...flagshipLevelAndShipCount(6,6),
     mkSTypeReqs(1,"CL",3,"DD"),
-    ...basicReqs,
   ]
 
   ret[15] = [
     ...flagshipLevelAndShipCount(9,6),
     mkSTypeReqs(2,"CVLike",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[16] = [
     ...flagshipLevelAndShipCount(11,6),
     mkSTypeReqs(1,"CL",2,"DD"),
-    ...basicReqs,
   ]
 
   // world 3
@@ -318,25 +297,21 @@ const expedReqs = (() => {
   ret[17] = [
     ...flagshipLevelAndShipCount(20,6),
     mkSTypeReqs(1,"CL",3,"DD"),
-    ...basicReqs,
   ]
 
   ret[18] = [
     ...flagshipLevelAndShipCount(15,6),
     mkSTypeReqs(3,"CVLike",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[19] = [
     ...flagshipLevelAndShipCount(20,6),
     mkSTypeReqs(2,"BBV",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[20] = [
     ...flagshipLevelAndShipCount(1,2),
     mkSTypeReqs(1,"SSLike",1,"CL"),
-    ...basicReqs,
   ]
 
   ret[21] = [
@@ -344,21 +319,18 @@ const expedReqs = (() => {
     Req.LevelSum(30),
     mkSTypeReqs(1,"CL",4,"DD"),
     Req.DrumCarrierCount(3),
-    ...basicReqs,
   ]
 
   ret[22] = [
     ...flagshipLevelAndShipCount(30,6),
     Req.LevelSum(45),
     mkSTypeReqs(1,"CA",1,"CL",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[23] = [
     ...flagshipLevelAndShipCount(50,6),
     Req.LevelSum(200),
     mkSTypeReqs(2,"BBV",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[24] = [
@@ -366,7 +338,6 @@ const expedReqs = (() => {
     Req.LevelSum(200),
     mkSTypeReqs(1,"CL",4,"DD"),
     Req.FSType("CL"),
-    ...basicReqs,
   ]
 
   // world 4
@@ -374,51 +345,43 @@ const expedReqs = (() => {
   ret[25] = [
     ...flagshipLevelAndShipCount(25,4),
     mkSTypeReqs(2,"CA",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[26] = [
     ...flagshipLevelAndShipCount(30,4),
     mkSTypeReqs(1,"CVLike",1,"CL",2,"DD"),
-    ...basicReqs,
   ]
 
   ret[27] = [
     ...flagshipLevelAndShipCount(1,2),
     mkSTypeReqs(2,"SSLike"),
-    ...basicReqs,
   ]
 
   ret[28] = [
     ...flagshipLevelAndShipCount(30,3),
     mkSTypeReqs(3,"SSLike"),
-    ...basicReqs,
   ]
 
   ret[29] = [
     ...flagshipLevelAndShipCount(50,3),
     mkSTypeReqs(3,"SSLike"),
-    ...basicReqs,
   ]
 
   ret[30] = [
     ...flagshipLevelAndShipCount(55,4),
     mkSTypeReqs(4,"SSLike"),
-    ...basicReqs,
   ]
 
   ret[31] = [
     ...flagshipLevelAndShipCount(60,4),
     Req.LevelSum(200),
     mkSTypeReqs(4,"SSLike"),
-    ...basicReqs,
   ]
 
   ret[32] = [
     ...flagshipLevelAndShipCount(5,3),
     mkSTypeReqs(1,"CT",2,"DD"),
     Req.FSType("CT"),
-    ...basicReqs,
   ]
 
   // world 5
@@ -426,25 +389,21 @@ const expedReqs = (() => {
   ret[33] = [
     ...flagshipLevelAndShipCount(1,2),
     mkSTypeReqs(2,"DD"),
-    ...basicReqs,
   ]
 
   ret[34] = [
     ...flagshipLevelAndShipCount(1,2),
     mkSTypeReqs(2,"DD"),
-    ...basicReqs,
   ]
 
   ret[35] = [
     ...flagshipLevelAndShipCount(40,6),
     mkSTypeReqs(2,"CVLike",1,"CA",1,"DD"),
-    ...basicReqs,
   ]
 
   ret[36] = [
     ...flagshipLevelAndShipCount(30,6),
     mkSTypeReqs(2,"AV",1,"CL",1,"DD"),
-    ...basicReqs,
   ]
 
   ret[37] = [
@@ -452,7 +411,6 @@ const expedReqs = (() => {
     Req.LevelSum(200),
     mkSTypeReqs(1,"CL",5,"DD"),
     Req.DrumCarrierCount(4),
-    ...basicReqs,
   ]
 
   ret[38] = [
@@ -461,14 +419,12 @@ const expedReqs = (() => {
     mkSTypeReqs(5,"DD"),
     Req.DrumCarrierCount(4),
     Req.DrumCount(8),
-    ...basicReqs,
   ]
 
   ret[39] = [
     ...flagshipLevelAndShipCount(3,5),
     Req.LevelSum(180),
     mkSTypeReqs(1,"AS",4,"SSLike"),
-    ...basicReqs,
   ]
 
   ret[40] = [
@@ -476,7 +432,6 @@ const expedReqs = (() => {
     Req.LevelSum(150),
     mkSTypeReqs(1,"CL",2,"AV",2,"DD"),
     Req.FSType("CL"),
-    ...basicReqs,
   ]
 
   return ret
@@ -520,8 +475,7 @@ const expedGSReqs = (() => {
 
 const getExpedReqs = (expedId, greatSuccess, resupply) => {
   const ret = {
-    norm: expedReqs[expedId].filter( obj =>
-      Array.isArray(obj) || obj.data.type !== "Resupply" ),
+    norm: expedReqs[expedId],
   }
 
   if (greatSuccess)

--- a/requirement.es
+++ b/requirement.es
@@ -42,7 +42,6 @@ Req.FSLevel = level => ({
   data: {type: "FSLevel", level},
 })
 
-
 Req.FSType = estypeName => ({
   checkFleet: onNonEmpty( fleet =>
     et.isESType[estypeName](fleet[0].stype)),
@@ -519,7 +518,16 @@ const expedGSReqs = (() => {
   return ret
 })()
 
+const getExpedReqs = (expedId, greatSuccess, resupply) => ({
+  norm: expedReqs[expedId].filter( obj => 
+    Array.isArray(obj) || obj.data.type !== "Resupply" ),
+  gs: expedGSReqs[expedId],
+  resupply: Req.Resupply,
+})
+
 export {
+  getExpedReqs,
+
   expedReqs,
   expedGSReqs,
   checkAllReq,

--- a/requirement.es
+++ b/requirement.es
@@ -16,7 +16,7 @@
 
 import * as et from './estype'
 import { enumFromTo } from './utils'
-const { _ } = window
+const _ = require('lodash')
 
 // NOTE: certainly if we allow "checkFleet" to return more info
 // and allow any rendering method to have access to that info,
@@ -178,11 +178,15 @@ const isEqualReqObj = (o1,o2) => {
 }
 
 // traverse a structure and perform "&&" on it
-// the structure must be an array or a single boolean value
+// the structure must be one of:
+// - a nested structure of array / object, whose "leaves" are all boolean values 
+// - a single boolean value
 const collapseResults = xs =>
   Array.isArray(xs)
     ? xs.every( collapseResults )
-    : xs
+    : typeof xs === "object" 
+      ? Object.keys(xs).every( k => collapseResults(xs[k]) )
+      : xs
 
 const mkSTypeReqs = function () {
   if (arguments.length % 2 === 1)

--- a/requirement.es
+++ b/requirement.es
@@ -518,18 +518,22 @@ const expedGSReqs = (() => {
   return ret
 })()
 
-const getExpedReqs = (expedId, greatSuccess, resupply) => ({
-  norm: expedReqs[expedId].filter( obj => 
-    Array.isArray(obj) || obj.data.type !== "Resupply" ),
-  gs: expedGSReqs[expedId],
-  resupply: Req.Resupply,
-})
+const getExpedReqs = (expedId, greatSuccess, resupply) => {
+  const ret = {
+    norm: expedReqs[expedId].filter( obj =>
+      Array.isArray(obj) || obj.data.type !== "Resupply" ),
+  }
+
+  if (greatSuccess)
+    ret.gs = expedGSReqs[expedId]
+
+  if (resupply)
+    ret.resupply = Req.Resupply
+  return ret
+}
 
 export {
   getExpedReqs,
-
-  expedReqs,
-  expedGSReqs,
   checkAllReq,
   collapseResults,
   collectUnmetReqs,

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const spec = it
 
 import * as estype from "../estype"
+import * as req from "../requirement"
 
 describe('estype', () => {
   describe('nameToId & idToName', () => {
@@ -21,5 +22,25 @@ describe('estype', () => {
       assert( estype.isESType.SSLike( ty.SSV ) )
       assert( ! estype.isESType.SSLike( ty.AV ) )
     })})
+})
 
+describe('requirement', () => {
+  describe('collapseResults', () => {
+    spec('tests', () => {
+      const aT = inp => assert( req.collapseResults( inp ) )
+      const aF = inp => assert( !req.collapseResults( inp ) )
+
+      aT( true )
+      aF( false )
+
+      aT( [true, true, {x: true, y: true} ] )
+      aF( [true, true, {x: false, y: true} ] )
+
+      aT( [[true,true],[],{}] )
+      aF( [[true,true],[false],{}] )
+
+      aT( {x: true, y: [{}, []], z: [true,true]} )
+      aF( {x: true, y: [{u:false}, []], z: [true,true]} )
+
+    })})
 })

--- a/utils.es
+++ b/utils.es
@@ -13,4 +13,10 @@ const throwWith = data => {
   throw data
 }
 
-export { enumFromTo, throwWith }
+const valMap = obj => f => {
+  const ret = {}
+  Object.keys(obj).map( k => ret[k] = f(obj[k]) )
+  return ret
+}
+
+export { enumFromTo, throwWith, valMap }


### PR DESCRIPTION
WIP.

- separate Req.Resupply from others as it's everywhere and sometimes we have to exclude it
- having a unified interface instead of `expedReqs` and `expedGSReqs`, that way `checkAllReqs` would work better
- moving pure logic from FleetPicker and other modules into requirement.es, so `fleet` representation doesn't need to be passed everywhere, also saving time for redoing checking.