### PR TITLE
Fix requirement for 44

### DIFF
--- a/exped-reqs/world-7.es
+++ b/exped-reqs/world-7.es
@@ -33,21 +33,19 @@ const defineWorld7 = defineExped => {
   )
   defineExped(44)(
     [
-      ...fslSc(45,6),
+      ...fslSc(35,6),
+      mk.LevelSum(210),
       mk.FleetCompo({
-        /*
-           The actual condition is 2CVL 1AV 1CL 2DD.
-           However, since AV also counts as CV-like,
-           this brings total CL-like to 3 rather than 2.
-         */
-        CVLike: 3,
+        CVLike: 2,
         AV: 1,
         CL: 1,
-        DD: 2,
+        DDorDE: 2,
       }),
       mk.DrumCarrierCount(3),
       mk.DrumCount(6),
+      mk.TotalAntiAir(200),
       mk.TotalAsw(200, true),
+      mk.TotalLos(150),
     ]
   )
   defineExped(45)([


### PR DESCRIPTION
According to https://wikiwiki.jp/kancolle/%E9%81%A0%E5%BE%81#Expedition07
```
Lv35, Lv210
全6隻。空母(水母,護母可)1隻、水母1隻、軽1隻、(駆+海防)2隻、他1隻必要(要検証)*27／「水母×2,軽×1,駆×3,任意の3隻にドラム缶各2つで合計6つ」
艦隊の合計値で、対空200 / 対潜200 / 索敵150 以上必要(装備込み。但し艦載機には補正が掛かる。詳細はこちらを参照。)
3隻以上にドラム缶(輸送用)が合計6個以上必要。合計8個以上かつキラキラ艦4隻以上で大成功確定。詳細はこちらを参照。
```