### PR TITLE
Fixed exped 44 requirement

### DIFF
--- a/exped-reqs/world-7.es
+++ b/exped-reqs/world-7.es
@@ -51,7 +51,7 @@ const defineWorld7 = defineExped => {
       ...fslSc(35,6),
       mk.LevelSum(210),
       mk.FleetCompo({
-        CVLike: 1,
+        CVLike: 2,
         AV: 1,
         CL: 1,
         DDorDE: 2,


### PR DESCRIPTION
Exped 44 need 1 cvlike and 1av (also count as cvlike) so makes it 2 cvlike and 1av to avoid failure