### PR TITLE
GS-rate-drum bug fixed

### DIFF
--- a/structs/ereq/gs-rate-drum.es
+++ b/structs/ereq/gs-rate-drum.es
@@ -12,7 +12,7 @@ const computeResult = (min, max) => {
     const gsRate = drumCount >= max ? Math.round((sparkledShipsCount * 15 + 40) / 0.0099) / 100 :
       min === 0 ? Math.round((sparkledShipsCount * 15 + 20) / 0.0099) / 100 :
       drumCount >= min ? Math.round((sparkledShipsCount * 15 + 5) / 0.0099) / 100 : 0
-    return {sat: gsRate >= 100, extra: {type: 'GSRate', rate: gsRate, drum: drumCount}}
+    return {sat: gsRate >= 100, extra: {type: 'GSRate', rate: gsRate}}
   }
 }
 

--- a/structs/ereq/gs-rate-drum.es
+++ b/structs/ereq/gs-rate-drum.es
@@ -5,16 +5,24 @@ import {
   sum,
 } from './common'
 
-class GSRateDrum {
-  static make = () => ({})
+const computeResult = (min, max) => {
+  return ships => {
+    const sparkledShipsCount = ships.filter(s => isShipSparkled(s)).length
+    const drumCount = sum(ships.map(({equips}) => equips.filter(isEqpDrum).length))
+    const gsRate = drumCount >= max ? Math.round((sparkledShipsCount * 15 + 40) / 0.0099) / 100 :
+      min === 0 ? Math.round((sparkledShipsCount * 15 + 20) / 0.0099) / 100 :
+      drumCount >= min ? Math.round((sparkledShipsCount * 15 + 5) / 0.0099) / 100 : 0
+    return {sat: gsRate >= 100, extra: {type: 'GSRate', rate: gsRate, drum: drumCount}}
+  }
+}
 
-  static prepare = () => () =>
-    onFleetShips(ships => {
-      const sparkledShipsCount = ships.filter(s => isShipSparkled(s)).length
-      const drumCount = sum(ships.map(({equips}) => equips.filter(isEqpDrum).length))
-      const gsRate = Math.round((sparkledShipsCount * 15 + 40) / 0.0099) / 100
-      return {sat: gsRate >= 100, extra: {type: 'GSRate', rate: gsRate, drum: drumCount}}
-    })
+class GSRateDrum {
+  static make = (min, max) => ({min, max})
+
+  static prepare = ({min, max}) => {
+    const d = computeResult(min, max)
+    return () => onFleetShips(d)
+  }
 }
 
 export { GSRateDrum }

--- a/ui/requirement-viewer/ereq-list-group-item/gs-rate-drum-item.es
+++ b/ui/requirement-viewer/ereq-list-group-item/gs-rate-drum-item.es
@@ -16,19 +16,13 @@ const describe = (x) => {
   </div>) : null
 }
 
-const GSRateDrumCheck = props =>
-  props.result.extra.drum >= props.ereq.max ? props.result.extra.rate :
-  props.ereq.min === 0 ? (props.result.extra.rate - 20.2) :
-  props.result.extra.drum >= props.ereq.min ? (props.result.extra.rate - 35.35) : 0
-
-const GSRateDrumItem = props => {
-  props.result.sat = GSRateDrumCheck(props) >= 100
-  return (<ItemTemplate
-    content={fmt(GSRateDrumCheck(props))}
-    tooltip={describe(GSRateDrumCheck(props))}
+const GSRateDrumItem = props => (
+  <ItemTemplate
+    content={fmt(props.result.extra.rate)}
+    tooltip={describe(props.result.extra.rate)}
     {...props}
   />
-)}
+)
 
 GSRateDrumItem.propTypes = {
   ereq: PTyp.object.isRequired,


### PR DESCRIPTION
it looks good to me now.

Can be optimized later: in exped 24 and 40, 6 sparkled ships meets 111.11% gs rate without any drum, which is correct, but gs checkers shows `Not Ready` (drum count does't meet gs requirement)